### PR TITLE
Fix late element cleanup and add in order test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,4 +95,5 @@ jobs:
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-std = ["futures-core/std"]
-
 default = ["std"]
+std = ["futures-core/std"]
 
 [dependencies]
 futures-core = { version = "0.3.28", default-features = false }

--- a/src/atomic_waker.rs
+++ b/src/atomic_waker.rs
@@ -2,7 +2,7 @@
 //! This wrapper type bridges the gap
 use crate::prelude::*;
 
-pub struct AtomicWaker {
+pub(crate) struct AtomicWaker {
     #[cfg(not(any(loom, doc)))]
     inner: atomic_waker::AtomicWaker,
     #[cfg(all(loom, not(doc)))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,4 +333,3 @@ mod tests {
         let _ = format!("{r:?}");
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub mod prelude {
     pub(crate) mod atomic {
         pub(crate) use crate::atomic_waker::AtomicWaker;
         pub(crate) use loom::sync::{
-            atomic::{fence, AtomicBool, AtomicU8, AtomicUsize},
+            atomic::{fence, AtomicU8, AtomicUsize},
             Arc,
         };
     }
@@ -134,7 +134,6 @@ where
         let is_last = remaining == 1;
 
         let val = if is_last {
-            //println!("Last reader to take() element at index {idx}");
             // SAFETY:
             // By our contract, this function is only called once per reader and each reader has
             // permission to read from this slot (each reader was accounted for when
@@ -165,7 +164,6 @@ where
         // When this is the case, we have to drop the element in the buffer since we already cloned
         // it into `val`, in addition to incrementing tail and waking the writer
         if missed_last_initally {
-            //println!("take({idx}): Read {remaining} initially but was {old_remaining} before decrementing remaining for index {idx}");
 
             // SAFETY:
             // 1. By our contract, `idx` is in the read section
@@ -227,7 +225,6 @@ where
         let missed_last_initally = !is_last && old_remaining == 1;
 
         if missed_last_initally {
-            println!("cleanup({idx}): Read {remaining} initially but was {old_remaining} before decrementing remaining for index {idx}");
 
             // SAFETY:
             // 1. By our contract, `idx` is in the read section

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,3 +333,4 @@ mod tests {
         let _ = format!("{r:?}");
     }
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,6 @@ where
         // When this is the case, we have to drop the element in the buffer since we already cloned
         // it into `val`, in addition to incrementing tail and waking the writer
         if missed_last_initally {
-
             // SAFETY:
             // 1. By our contract, `idx` is in the read section
             // 2. This is the last time `idx` will be accessed because we observed `remaining == 1`
@@ -225,7 +224,6 @@ where
         let missed_last_initally = !is_last && old_remaining == 1;
 
         if missed_last_initally {
-
             // SAFETY:
             // 1. By our contract, `idx` is in the read section
             // 2. This is the last time `idx` will be accessed because we observed `remaining == 1`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,11 +155,10 @@ where
         };
 
         // we are done with this slot
-        let prev_remaining = self.slots[idx].remaining.fetch_sub(1, Ordering::AcqRel);
-        dbg!(prev_remaining);
+        self.slots[idx].remaining.fetch_sub(1, Ordering::AcqRel);
 
         if is_last {
-            println!("Waking writer");
+            //println!("Waking writer");
             // Wake waker now that remaining is zero
             self.writer_waker.wake();
         }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -55,7 +55,6 @@ where
             if Arc::strong_count(&self.info) == 1 {
                 return Err(TryRecvError::Disconnected);
             } else {
-                // TODO: make sure we don't race with the writer being dropped here, miss a wakeup and hang
                 return Err(TryRecvError::Empty);
             }
         }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -65,6 +65,7 @@ where
             assert!(self.next >= tail);
         }
         let idx = self.next % self.shared.slots.len();
+
         let v = unsafe { self.shared.take(idx) };
         self.next += 1;
 
@@ -74,7 +75,6 @@ where
     pub fn leave(self) {
         // Drop impl handles cleanup
     }
-
 
     /// Returns an estimate of the number of buffered elements
     pub fn len(&self) -> usize {
@@ -133,7 +133,6 @@ where
 
             for i in tail..head {
                 let idx = i % self.shared.slots.len();
-                println!("Reader cleaning {i}");
                 // SAFETY:
                 // TODO
                 unsafe { self.shared.cleanup(idx) };

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -59,7 +59,7 @@ where
             }
         }
 
-        #[cfg(debug_assertions)]
+        #[cfg(any(debug_assertions, loom))]
         {
             let tail = self.shared.tail.load(Ordering::Acquire);
             assert!(self.next >= tail);

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -59,6 +59,10 @@ where
         val: &mut Option<T>,
         cx: &mut Context<'_>,
     ) -> Poll<()> {
+        // register before trying to send to avoid a race between the broadcast failing, and a
+        // reader waking us racing with us calling register
+        self.shared.writer_waker.register(cx.waker());
+
         match self.as_mut().try_broadcast_inner(val) {
             Ok(()) => {
                 // TODO: optimize?
@@ -67,11 +71,7 @@ where
                 }
                 Poll::Ready(())
             }
-
-            Err(()) => {
-                self.shared.writer_waker.register(cx.waker());
-                Poll::Pending
-            }
+            Err(()) => Poll::Pending,
         }
     }
 
@@ -96,7 +96,8 @@ where
             // or some readers have left and we need to account for them
             self.try_cleanup_readers(Some(fence), false);
 
-            if self.shared.slots[fence].remaining.load(Ordering::Acquire) != 0 {
+            let remaining_readers = self.shared.slots[fence].remaining.load(Ordering::Acquire);
+            if remaining_readers != 0 {
                 // Slot still taken after trying cleanup (full)
                 return Err(());
             }
@@ -168,8 +169,8 @@ where
 
             let info = self.readers.remove(left_reader_index);
 
-            // The release store(true) to `has_left` happens after the release store to `left_with_next`
-            // Because `has_left` is not reused after being set by a leaving reader we are
+            // The release store(WRITER_CLEANUP) to `cleanup_state` happens after the release store to `next`
+            // Because `cleanup_state` is not reused after being set by a leaving reader we are
             // seeing the reader's next value at the time it left
             let reader_tail = info.next.load(Ordering::Acquire);
             let reader_head = self.shared.head.load(Ordering::Acquire);
@@ -243,24 +244,14 @@ where
 
         self.try_cleanup_readers(None, true);
 
-        // the only remaining readers are responsible for cleaning up after themselves
-        debug_assert_eq!(
-            self.readers
-                .iter()
-                .filter(|r| r.cleanup_state.load(Ordering::Acquire) == reader_cleanup::RUNNING)
-                .count(),
-            0
-        );
-
-        debug_assert_eq!(
-            self.readers
-                .iter()
-                .filter(
-                    |r| r.cleanup_state.load(Ordering::Acquire) == reader_cleanup::WRITER_CLEANUP
-                )
-                .count(),
-            0
-        );
+        // Sanity check that the remaining readers are responsible for cleaning up after themselves
+        #[cfg(debug_assertions)]
+        {
+            for r in &self.readers {
+                let state = r.cleanup_state.load(Ordering::Acquire);
+                assert!(state == reader_cleanup::READER_CLEANUP);
+            }
+        }
     }
 }
 

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -111,8 +111,9 @@ fn leave2() {
         t2.join().unwrap();
 
         assert_eq!(ndrops0.load(Ordering::Acquire), 1);
-        // value received on two threads and dropped twice (after clone)
-        assert_eq!(ndrops1.load(Ordering::Acquire), 2);
+        // value received on two threads and dropped twice (after clone), or more than twice due to
+        // semantics of take
+        assert!(ndrops1.load(Ordering::Acquire) >= 2);
     });
 }
 

--- a/tests/miri.rs
+++ b/tests/miri.rs
@@ -116,7 +116,7 @@ async fn it_runs_blocked_writes() {
         c.broadcast(false).await;
     });
 
-    // unblock sender by receiving
+    // unblock writer by receiving
     assert_eq!(r1.recv().await, Ok(true));
     // drop r1 to release other thread and safely drop c
     drop(r1);
@@ -179,10 +179,10 @@ async fn test_busy() {
 
 #[tokio::test]
 async fn in_order() {
-    let num_elements = 3;
-    let threads = 2;
+    let num_elements = 1000;
+    let threads = 10;
 
-    let mut bus = crate::Bus::<u32>::new(2);
+    let mut bus = crate::Bus::<u32>::new(4);
     let rxs: Vec<_> = (0..threads)
         .map(|_| {
             let mut rx = bus.add_rx();

--- a/tests/miri.rs
+++ b/tests/miri.rs
@@ -179,10 +179,10 @@ async fn test_busy() {
 
 #[tokio::test]
 async fn in_order() {
-    let num_elements = 32;
-    let threads = 4;
+    let num_elements = 3;
+    let threads = 2;
 
-    let mut bus = crate::Bus::<u32>::new(3);
+    let mut bus = crate::Bus::<u32>::new(2);
     let rxs: Vec<_> = (0..threads)
         .map(|_| {
             let mut rx = bus.add_rx();

--- a/tests/miri.rs
+++ b/tests/miri.rs
@@ -179,10 +179,21 @@ async fn test_busy() {
 
 #[tokio::test]
 async fn in_order() {
-    let num_elements = 1000;
-    let threads = 10;
+    #[cfg(miri)]
+    let num_elements = 128;
+    #[cfg(miri)]
+    let threads = 3;
+    #[cfg(miri)]
+    let cap = 4;
 
-    let mut bus = crate::Bus::<u32>::new(4);
+    #[cfg(not(miri))]
+    let num_elements = 10_000_000;
+    #[cfg(not(miri))]
+    let threads = 12;
+    #[cfg(not(miri))]
+    let cap = 1024;
+
+    let mut bus = crate::Bus::<u32>::new(cap);
     let rxs: Vec<_> = (0..threads)
         .map(|_| {
             let mut rx = bus.add_rx();

--- a/tests/miri.rs
+++ b/tests/miri.rs
@@ -144,7 +144,7 @@ async fn it_runs_blocked_reads() {
 #[tokio::test]
 async fn test_busy() {
     // start a bus with limited space
-    let mut bus = Bus::new(2);
+    let mut bus = Bus::new(3);
 
     // first receiver only receives 5 items
     let mut rx1 = bus.add_rx();
@@ -152,6 +152,7 @@ async fn test_busy() {
         for _ in 0..5 {
             rx1.recv().await.unwrap();
         }
+        println!("Dropping reader 1");
         drop(rx1);
     });
 
@@ -161,6 +162,7 @@ async fn test_busy() {
         for _ in 0..10 {
             rx2.recv().await.unwrap();
         }
+        println!("Dropping reader 2");
         drop(rx2);
     });
 

--- a/tests/miri.rs
+++ b/tests/miri.rs
@@ -212,7 +212,6 @@ async fn in_order() {
 
     for i in 0..num_elements {
         bus.broadcast(i as u32).await;
-        
     }
     rxs.into_iter().for_each(|t| t.join().unwrap());
 }

--- a/tests/native.rs
+++ b/tests/native.rs
@@ -2,7 +2,7 @@
 #![cfg(all(not(loom), not(miri)))]
 
 use futures::StreamExt;
-pub use hyperbus::prelude::*;
+pub use hyperbus::*;
 
 #[tokio::test]
 async fn it_streams() {


### PR DESCRIPTION
Fixes an issue where due to memory orderings sometimes elements aren't dropped when read by the last reader.

Its possible for multiple readers to race on `remaining.fetch_sub(1)`, observing `remaining > 1`, even though someone has to deal with the last element. When this is the case, we have to drop the element in the buffer since we already cloned it into `val`, in addition to incrementing tail and waking the writer

See: https://github.com/TroyNeubauer/hyperbus/blob/1ae91e410fe6cf1f1ed3c2b154d80570200cc5e3/src/lib.rs#L157-L185